### PR TITLE
Optimize document filtering and take function names from documents

### DIFF
--- a/src/pages/DashboardPage/DocumentsFromScrapper.tsx
+++ b/src/pages/DashboardPage/DocumentsFromScrapper.tsx
@@ -108,8 +108,18 @@ export const DocumentsFromScrapper = () => {
         }
 
         return (
-          document.function.toLowerCase() === job.name.toLowerCase() &&
-          document.locality.toLowerCase() === job.uat.toLowerCase() &&
+          0 ===
+            document.function
+              .toLowerCase()
+              .localeCompare(job.name.toLowerCase(), "en", {
+                sensitivity: "base",
+              }) &&
+          0 ===
+            document.locality
+              .toLowerCase()
+              .localeCompare(job.uat.toLowerCase(), "en", {
+                sensitivity: "base",
+              }) &&
           moment(document.date, "DD.MM.YYYY") >= moment(job.dateStart) &&
           moment(document.date, "DD.MM.YYYY") <= moment(job.dateEnd)
         );


### PR DESCRIPTION
## Issue reference

Resolves #160

## Small description of change

- don't filter by institution name anymore in documents page
- gather function names from scrapped documents
- ignore locale when comparing strings for filtering documents

## Type of Change

- [x] Fix
- [ ] Feature
- [ ] Documentation Updates
- [ ] Breaking Changes