### PR TITLE
Show correct number of documents for subject

### DIFF
--- a/src/resources/tableRowDefs/subjectsTableRowDefs.ts
+++ b/src/resources/tableRowDefs/subjectsTableRowDefs.ts
@@ -87,7 +87,7 @@ export const assignedSubjectsTableRowDefs: RowCell[] = [
   {
     cellType: "text",
     field: "docCount",
-    fields: [{ name: "ocrokCount" }],
+    fields: [{ name: "docCount" }],
     align: "center",
   },
   {


### PR DESCRIPTION
## Issue reference

Resolves #163.

## Small description of change

Fixed the name of the field holding the number of uploaded documents for subject.

## Type of Change

- [x] Fix
- [ ] Feature
- [ ] Documentation Updates
- [ ] Breaking Changes
