### PR TITLE
Same declaration of interest is shown twice in the list of loaded declarations for a subject

### DIFF
--- a/src/pages/DashboardPage/DocumentsFromScrapper.tsx
+++ b/src/pages/DashboardPage/DocumentsFromScrapper.tsx
@@ -92,6 +92,10 @@ export const DocumentsFromScrapper = () => {
   const [documentsUploadedWithFailure, setDocumentsUploadedWithFailure] =
     useState<boolean>(false);
 
+  const isDeclarationOfWealth = (
+    document: DocumentsFromScrapperResult
+  ): boolean => "A" === document.type || document.type.includes("avere");
+
   const loadInstitutions = async () => {
     const response = await institutionService.getInstitutions({
       token: tokenStatus.token,
@@ -314,12 +318,7 @@ export const DocumentsFromScrapper = () => {
         subjectId: subject?.id,
         status: 0,
         jobId: selectedJob?.id,
-        type:
-          selectedDocument.type === "I"
-            ? 2
-            : selectedDocument.type === "A"
-            ? 1
-            : 2,
+        type: isDeclarationOfWealth(selectedDocument) ? 1 : 2,
         name: selectedDocument.filename,
         downloadUrl: dataUrl
           .replace(":filename", selectedDocument.filename)
@@ -715,10 +714,9 @@ export const DocumentsFromScrapper = () => {
                       .map((document, index) => ({
                         ...document,
                         index: index + 1,
-                        type:
-                          document.type === "A"
-                            ? "Declaratie de avere"
-                            : "Declaratie de interese",
+                        type: isDeclarationOfWealth(document)
+                          ? "Declaratie de avere"
+                          : "Declaratie de interese",
                         chamberName:
                           document.chamber === 1
                             ? "Senat"


### PR DESCRIPTION
## Issue reference

Resolves #189.

## Small description of change

Fix the way a declaration's type is determined. The bug was generated because the code couldn't properly determine if a declaration was a wealth or an interests one. In our case we had a declaration which was of interests and another which was of wealth, but both were shown as being of interests. 

## Type of Change

- [x] Fix
- [ ] Feature
- [ ] Documentation Updates
- [ ] Breaking Changes
